### PR TITLE
Water Rate Issue Fix

### DIFF
--- a/app/Http/Controllers/ConsumerLedgerController.php
+++ b/app/Http/Controllers/ConsumerLedgerController.php
@@ -43,9 +43,9 @@ class ConsumerLedgerController extends Controller
         $transactions = Transaction::orderBy('created_at', 'asc')->where('customer_id', $account_number)->paginate(10);
 
         $rate = [];
-        
+
         $rates = WaterRate::all();
-        
+
 
         for($i = 0; $i < count($rates); $i++)
         {
@@ -65,10 +65,10 @@ class ConsumerLedgerController extends Controller
         // dd($date[1]);
         return view('pages.consumer-ledger',[
             'customer' => [
-                'fullname' => $fullname, 
-                'address' => $address, 
-                'transactions' => $transactions, 
-                'account' => $acc, 
+                'fullname' => $fullname,
+                'address' => $address,
+                'transactions' => $transactions,
+                'account' => $acc,
                 'balance' => $balance,
                 'connection_type' => $customer->connection_type,
             ],
@@ -92,6 +92,7 @@ class ConsumerLedgerController extends Controller
             'billing_meter_ips' => $request->meter_ips,
             'billing_total' => $request->total,
             'balance' => $request->total,
+            'user_id' => Auth::id(),
             'posted_by' => Auth::id()
         ];
 

--- a/app/Http/Controllers/SurchargeController.php
+++ b/app/Http/Controllers/SurchargeController.php
@@ -4,17 +4,32 @@ namespace App\Http\Controllers;
 
 use App\Models\Surcharge;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
 
 class SurchargeController extends Controller
 {
+
+    public function getSurcharge()
+    {
+        return response()->json(['data' => Surcharge::all()]);
+    }
+
     public function update(Request $request)
     {
-        $rate = $request->rate? $request->rate : '0';
+        $validator = Validator::make($request->all(),[
+            'surcharge_rate' => 'required|numeric'
+        ]);
+
+        if($validator->fails()){
+            return response()->json(['updated' => false, 'errors' => $validator->errors()]);
+        }
+
+        $rate = $request->surcharge_rate? $request->surcharge_rate : '0';
 
         $surcharge = Surcharge::find(1);
 
-        $surcharge->rate = $rate;
+        $surcharge->rate = $rate / 100;
         $surcharge->save();
-        return redirect(route('admin.dashboard'));
+        return response()->json(['updated' => true, 'message' => 'Surcharge has been successfully updated!']);
     }
 }

--- a/app/Http/Controllers/WaterRateController.php
+++ b/app/Http/Controllers/WaterRateController.php
@@ -4,11 +4,31 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\WaterRate;
+use Illuminate\Support\Facades\Validator;
 
 class WaterRateController extends Controller
 {
+    private function customValidator($requestData)
+    {
+        $validator = Validator::make($requestData,[
+            'type' => 'required',
+            'min_rate' => 'required|numeric',
+            'excess_rate' => 'required|numeric'
+        ],[
+            'type' => 'Water Type should not be empty',
+            'min_rate' => 'Min Rate should not be empty',
+            'excess_rate' => 'Excess Rate should not be empty'
+        ]);
+        return $validator;
+    }
+
     public function update(Request $request)
     {
+        $validator = $this->customValidator($request->all());
+        if($validator->fails()){
+            return response()->json(['updated' => false, 'errors' => $validator->errors()]);
+        }
+
         $requestData = $request->all();
 
         $requestData['min_rate'] = $requestData['min_rate'] ? $requestData['min_rate'] : '0';
@@ -16,10 +36,18 @@ class WaterRateController extends Controller
 
         $water_rate = WaterRate::find($requestData['type']);
 
-        $water_rate->min_rate = $requestData['min_rate'];
-        $water_rate->excess_rate = $requestData['excess_rate'];
+        $min_rate = $requestData['min_rate'] / 100;
+        $excess_rate = $requestData['excess_rate'] / 100;
+
+        $water_rate->min_rate = $min_rate;
+        $water_rate->excess_rate = $excess_rate;
         $water_rate->save();
 
-        return redirect(route('admin.dashboard'));
+        return response()->json(['updated' => true, 'message' => "$water_rate->type has been successfully updated"]);
+    }
+
+    public function getWaterRates()
+    {
+        return response()->json(['data' => WaterRate::all()]);
     }
 }

--- a/database/factories/WaterRateFactory.php
+++ b/database/factories/WaterRateFactory.php
@@ -23,8 +23,8 @@ class WaterRateFactory extends Factory
     {
         return [
             'consumption_max_range' => 10,
-            'min_rate' => 65,
-            'excess_rate' => 10,
+            'min_rate' => 0.65,
+            'excess_rate' => 0.10,
         ];
 
     }

--- a/database/seeders/WaterRateSeeder.php
+++ b/database/seeders/WaterRateSeeder.php
@@ -14,12 +14,19 @@ class WaterRateSeeder extends Seeder
      */
     public function run()
     {
-        $names = ['Residential', 'Institutional', 'Commercial'];
-        for($x = 0 ; $x < 3 ; $x++)
+        $names = ['Residential', 'Institutional'];
+        for($x = 0 ; $x < 2 ; $x++)
         {
             WaterRate::factory()->create([
                 'type' => $names[$x],
             ]);
         }
+
+        WaterRate::create([
+            'type' => 'Commercial',
+            'consumption_max_range' => 10,
+            'min_rate' => 1.1,
+            'excess_rate' => 0.15,
+        ]);
     }
 }

--- a/public/assets/js/new_billing.js
+++ b/public/assets/js/new_billing.js
@@ -2,11 +2,11 @@ $(document).ready(function(){
 
     $("#billing-form").on('submit', function(e){
         e.preventDefault();
-        
+
         let registerForm = document.getElementById('billing-form')
         let actionURI = registerForm.getAttribute('action')
 
-        
+
         if($('#reading_date').val() != '')
         {
             $('#save-billing').html('<i class="far fa-spinner fa-spin"></i>&nbsp; Processing ...');
@@ -62,7 +62,7 @@ $(document).ready(function(){
             const meter_consumption = parseInt($(this).val()) - parseInt($('#meter-reading').val());
             const total_consumption = ((meter_consumption - max_range) * excess_rate) + min_rates;
             const amount_consumption = meter_consumption <= max_range ? min_rates : total_consumption;
-            
+
             $('#consumption').val(meter_consumption);
             $('#surcharge_amount').val(surcharge);
             $('#amount').val(amount_consumption);

--- a/public/assets/js/surcharge.js
+++ b/public/assets/js/surcharge.js
@@ -1,0 +1,31 @@
+$(document).ready(async() => {
+    let surcharge_value = await fetch('/admin/surcharge');
+    surcharge_value = await surcharge_value.json();
+
+    this.surcharge_rate.value = Math.round(surcharge_value.data[0].rate * 100);
+
+    this.surcharge_form.addEventListener('submit', async(e) =>{
+        e.preventDefault();
+        let uri = this.surcharge_form.getAttribute('action');
+        let formData = new FormData(this.surcharge_form)
+
+        let response = await fetch(uri, {
+            method: 'post',
+            body: formData
+        });
+
+        response = await response.json();
+
+        if(response.updated == true){
+            Swal.fire('Great!',response.message,'success').then(function(result){
+                if(result.isConfirmed)
+                {
+                    window.location.reload();
+                }
+            })
+        }else{
+            this.surcharge_rate.classList.add('border', 'border-danger');
+        }
+    })
+})
+

--- a/public/assets/js/water_rates.js
+++ b/public/assets/js/water_rates.js
@@ -1,0 +1,93 @@
+$(document).ready(() => {
+    async function getWaterRates(){
+        let water_rates = await fetch('/admin/water-rate');
+        water_rates = await water_rates.json();
+        return await  water_rates;
+    }
+
+    async function setWaterRates(){
+        let water_types = document.getElementById('type');
+        let water_rates =await getWaterRates();
+
+        for(let i = 0 ; i < water_rates.data.reverse().length; i++)
+        {
+            let option = document.createElement('option');
+            option.text = water_rates.data[i].type;
+            option.value = water_rates.data[i].id;
+            water_types.add(option,0);
+        }
+    }
+
+    async function WaterTypeChangeValue(){
+        let water_rates = await getWaterRates();
+        let water_types = document.getElementById('type');
+        let min_rate = document.getElementById('min_rate');
+        let excess_rate = document.getElementById('excess_rate');
+
+        min_rate.value = Math.round(water_rates.data[water_types.value - 1].min_rate * 100);
+        excess_rate.value = Math.round(water_rates.data[water_types.value - 1].excess_rate * 100);
+    }
+
+    function AddDangerBorder(elementId)
+    {
+        let element = document.getElementById(elementId);
+        element.classList.add("border", 'border-danger');
+    }
+
+    function RemoveBorders(){
+        if(this.type.classList.contains('border')){
+            this.type.classList.remove('border', 'border-danger')
+        }
+        if(this.min_rate.classList.contains('border')){
+            this.min_rate.classList.remove('border', 'border-danger')
+        }
+        if(this.excess_rate.classList.contains('border')){
+            this.excess_rate.classList.remove('border', 'border-danger')
+        }
+    }
+
+    setWaterRates();
+
+    document.getElementById('type').onchange = () => {
+        if(document.getElementById('type').value === ""){
+            document.getElementById('min_rate').value = "";
+            document.getElementById('excess_rate').value = "";
+        }
+        else
+        {
+            WaterTypeChangeValue();
+        }
+    }
+
+
+    this.water_rate_form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        let url = this.water_rate_form.getAttribute('action');
+        let formData =new FormData(this.water_rate_form);
+
+        let response = await fetch(url,{
+            method: 'post',
+            body: formData
+        });
+
+        response = await response.json();
+
+        RemoveBorders();
+
+        if(response.updated == true){
+            Swal.fire('Great!',response.message,'success').then(function(result){
+                if(result.isConfirmed)
+                {
+                    window.location.reload();
+                }
+            })
+        }else{
+            let keys = Object.keys(response.errors)
+            for(key of keys){
+                AddDangerBorder(key)
+            }
+        }
+    })
+
+
+})

--- a/public/assets/js/water_rates.js
+++ b/public/assets/js/water_rates.js
@@ -1,13 +1,10 @@
-$(document).ready(() => {
-    async function getWaterRates(){
-        let water_rates = await fetch('/admin/water-rate');
-        water_rates = await water_rates.json();
-        return await  water_rates;
-    }
+$(document).ready(async() => {
+    let water_rates_value = await fetch('/admin/water-rate');
+    water_rates_value = await water_rates_value.json();
 
     async function setWaterRates(){
         let water_types = document.getElementById('type');
-        let water_rates =await getWaterRates();
+        let water_rates = await water_rates_value;
 
         for(let i = 0 ; i < water_rates.data.reverse().length; i++)
         {
@@ -19,7 +16,7 @@ $(document).ready(() => {
     }
 
     async function WaterTypeChangeValue(){
-        let water_rates = await getWaterRates();
+        let water_rates = await water_rates_value;
         let water_types = document.getElementById('type');
         let min_rate = document.getElementById('min_rate');
         let excess_rate = document.getElementById('excess_rate');

--- a/resources/views/templates/surcharge.blade.php
+++ b/resources/views/templates/surcharge.blade.php
@@ -6,13 +6,20 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body pb-4 px-5">
-                <form action="{{ route('admin.surcharge-update') }}" method="post">
+                <form action="{{ route('admin.surcharge-update') }}" id="surcharge_form" method="post">
                     @csrf
                     <label for="rate">Surcharge Rate</label>
-                    <input type="number" name="rate" id="rate" class="form-control" placeholder="0.00">
-                    <button class="btn btn-primary btn-md mt-3"><i data-feather="save" width="20" class="pb-1"></i> Save</button>
+                    <div class="input-group">
+                        <input type="number" name="surcharge_rate" id="surcharge_rate" class="form-control" placeholder="0.00">
+                        <div class="input-group-text">
+                            <span>%</span>
+                        </div>
+                    </div>
+                    <button type="submit" class="btn btn-primary btn-md mt-3"><i data-feather="save" width="20" class="pb-1"></i> Save</button>
                 </form>
             </div>
         </div>
     </div>
 </div>
+
+<script src="{{ asset('assets/js/surcharge.js')}}" defer></script>

--- a/resources/views/templates/water-rate.blade.php
+++ b/resources/views/templates/water-rate.blade.php
@@ -6,21 +6,40 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body pb-4 px-5">
-                <form action="{{ route('admin.water-rate-update') }}" method="post">
+                <form action="{{ route('admin.water-rate-update') }}" id="water_rate_form" method="post">
                     @csrf
-                    <label for="type">Type</label>
-                    <select name="type" id="type" class="form-control">
-                        <option value="1">Residential</option>
-                        <option value="2">Institutional</option>
-                        <option value="3">Commercial</option>
-                    </select>
-                    <label for="min_rate">Minimum Rate</label>
-                    <input type="number" name="min_rate" class="form-control" placeholder="0.00">
-                    <label for="excess_rate">Excess Rate</label>
-                    <input type="number" name="excess_rate" id="excess_rate" class="form-control" placeholder="0.00">
-                    <button class="btn btn-primary btn-md mt-3"><i data-feather="save" width="20" class="pb-1"></i> Save</button>
+                    <div class="form-group">
+                        <label for="type">Type</label>
+                        <select name="type" id="type"  class="form-control">
+                            <option value=""></option>
+                        </select>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="min_rate">Minimum Rate</label>
+                        <div class="input-group">
+                            <input type="number" id="min_rate" name="min_rate" class="form-control" placeholder="0.00" min="1" >
+                            <div class="input-group-text">
+                                <span>%</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="excess_rate">Excess Rate</label>
+                        <div class="input-group">
+                            <input type="number" name="excess_rate" id="excess_rate" class="form-control" placeholder="0.00" min="1" >
+                            <div class="input-group-text">
+                                <span>%</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <button type="submit"  class="btn btn-primary btn-md mt-3"><i data-feather="save" width="20" class="pb-1"></i> Save</button>
                 </form>
             </div>
         </div>
     </div>
 </div>
+<script src="//cdn.jsdelivr.net/npm/sweetalert2@10"></script>
+<script src="{{ asset('assets/js/water_rates.js') }}" defer></script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -39,7 +39,7 @@ Route::prefix('admin')->middleware('auth')->name('admin.')->group(function(){
         'existing-customers'=>ExistingCustomerController::class,
     ]);
 
-    
+
     Route::post('/logout',[LogoutUserController::class,'logout'])->middleware('auth')->name('logout');
     Route::get('/consumers',[CustomerController::class,'showAll'])->middleware('auth')->name('customers');
     Route::get('/transaction/new',[TransactionsController::class,'index'])->middleware('auth')->name('new-transaction');
@@ -79,6 +79,7 @@ Route::prefix('admin')->middleware('auth')->name('admin.')->group(function(){
     Route::get('/transfer-meter',[TransferOfMeterController::class, 'index'])->name('transfer-meter');
     Route::get('/search-info',[TransferOfMeterController::class, 'search'])->name('search-info');
 
+    Route::get('/water-rate', [WaterRateController::class, 'getWaterRates'])->middleware('access.authorize');
     Route::post('/water-rate', [WaterRateController::class, 'update'])->name('water-rate-update');
     Route::post('/surcharge', [SurchargeController::class, 'update'])->name('surcharge-update');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -81,6 +81,7 @@ Route::prefix('admin')->middleware('auth')->name('admin.')->group(function(){
 
     Route::get('/water-rate', [WaterRateController::class, 'getWaterRates'])->middleware('access.authorize');
     Route::post('/water-rate', [WaterRateController::class, 'update'])->name('water-rate-update');
+    Route::get('/surcharge', [SurchargeController::class, 'getSurcharge'])->middleware('access.authorize');
     Route::post('/surcharge', [SurchargeController::class, 'update'])->name('surcharge-update');
 
     Route::get('/consumer-ledger',[ConsumerLedgerController::class, 'index'])->name('consumer-ledger');


### PR DESCRIPTION
- [x] Update and fix Seeder of Water Rate
![image](https://user-images.githubusercontent.com/43285621/123455557-6c52fc80-d614-11eb-9b1c-11e6ee9fe907.png)

- [x] During page load, water rate data will be fetch from the database
![image](https://user-images.githubusercontent.com/43285621/123455851-c358d180-d614-11eb-9670-12bd0489655e.png)
![image](https://user-images.githubusercontent.com/43285621/123455911-d4a1de00-d614-11eb-986f-aa14df08575e.png)

- [x] Add percent sign in min rate and excess rate fields
- [x] If the dropdown change value the min rate and excess rate values will change also
![image](https://user-images.githubusercontent.com/43285621/123456819-de781100-d615-11eb-9d95-245a626eba0e.png)
![image](https://user-images.githubusercontent.com/43285621/123456844-e46df200-d615-11eb-8cfd-f4523f8a9185.png)

- [x] Make water rate form submission asynchronous
![image](https://user-images.githubusercontent.com/43285621/123457022-1717ea80-d616-11eb-8bce-1a6d9257559d.png)
![image](https://user-images.githubusercontent.com/43285621/123459056-5d6e4900-d618-11eb-8f98-88d598e76e30.png)

- [x] If fields are empty, add fields danger border
![image](https://user-images.githubusercontent.com/43285621/123457132-3151c880-d616-11eb-9438-546729ea5b69.png)
![image](https://user-images.githubusercontent.com/43285621/123458582-c608f600-d617-11eb-9834-9d9d0b18866c.png)

- [x] But if fields are filled-up, the border will be removed after form submission
![image](https://user-images.githubusercontent.com/43285621/123458714-efc21d00-d617-11eb-9c33-1dc8b2daddaa.png)


- [x] Convert whole number into decimal value of the rate before saving to database
![image](https://user-images.githubusercontent.com/43285621/123457454-8392e980-d616-11eb-9c7c-bd9e10588ea3.png)

- [x] Convert decimal number into whole number for displaying the value of rate
![image](https://user-images.githubusercontent.com/43285621/123457540-9c030400-d616-11eb-9184-724b682a8c86.png)
