### PR TITLE
Add new column (request_number) in Service

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -31,8 +31,8 @@ class DashboardController extends Controller
         $data = [
             'customer' => $this->constructArray('Number of Customer', $customerCount, route('admin.existing-customers.index')),
             'user' => $this->constructArray('Number of User', $userCount, route('admin.users.index')),
-            'service_pending' =>$this->constructArray('Number of Pending Services', $servicePendingCount, route('admin.services-list.index')),
-            'service_pending_for_payment' => $this->constructArray('Number of Pending for Payment', $servicePendingForPaymentCount, route('admin.services-list.filter', ['filter' => Service::$PENDING_FOR_PAYMENT]))
+            'service_pending' =>$this->constructArray('Number of Pending Services', $servicePendingCount, route('admin.services.index')),
+            'service_pending_for_payment' => $this->constructArray('Number of Pending for Payment', $servicePendingForPaymentCount, route('admin.services.filter', ['filter' => Service::$PENDING_FOR_PAYMENT]))
         ];
 
         return view('pages.dashboard', [

--- a/app/Http/Controllers/NewConnectionController.php
+++ b/app/Http/Controllers/NewConnectionController.php
@@ -32,7 +32,8 @@ class NewConnectionController extends Controller
             'customer_id' => $customer->account_number,
             'type_of_service' => $serviceType,
             'status' => $initialStatus,
-            'start_status' =>  $initialStatus
+            'start_status' =>  $initialStatus,
+            'request_number' => Service::generateUniqueIdentifier()
         ]);
         TransactionLog::create([
             'customer_organization_name' => $requestData['org_name'] ?? '',

--- a/app/Http/Controllers/ServiceController.php
+++ b/app/Http/Controllers/ServiceController.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Arr;
 
 class ServiceController extends Controller
 {
-  
+
     private function getServices()
     {
         return Arr::except(Service::getServiceTypes(),['new_connection']);
@@ -32,7 +32,7 @@ class ServiceController extends Controller
 
     public function filter(Request $request){
         if($request->filter == 'none'){
-            return redirect(route('admin.services-list.index'));
+            return redirect(route('admin.services.index'));
         }
         $services = Service::where('status', $request->filter)->paginate(10);
         $status = Service::getServiceStatus();
@@ -44,7 +44,7 @@ class ServiceController extends Controller
     }
 
     public function search(Request $request)
-    {  
+    {
         try{
             $customer= Customer::findOrFail($request->account_number);
             return view('pages.add-service', [
@@ -57,12 +57,12 @@ class ServiceController extends Controller
                     'account_number'=>'Account number not found!'
                 ])->withInput();
         }
-      
+
     }
 
 
     public function create()
-    { 
+    {
         return view('pages.add-service', [
             'route' => 'admin.search-customer',
             'services'=>$this->getServices()
@@ -72,7 +72,6 @@ class ServiceController extends Controller
 
     public function store(StoreServiceRequest $request)
     {
-    
        $initialStatus=Service::getInitialStatus($request->service_type);
        Service::create([
             'customer_id'=>$request->account_number,
@@ -82,6 +81,7 @@ class ServiceController extends Controller
             'work_schedule'=>$request->service_schedule,
             'status'=>$initialStatus,
             'start_status'=>$initialStatus,
+            'request_number'=>Service::generateUniqueIdentifier()
        ]);
 
        return back()->with([

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -41,7 +41,8 @@ class Service extends Model
         'landmarks',
         'work_schedule',
         'status',
-        'start_status'
+        'start_status',
+        'request_number'
     ];
 
     protected $processFlow=[
@@ -78,6 +79,13 @@ public function prettyServiceType()
     public static function withStatus($status)
     {
         return self::where('status', $status)->paginate(self::$PAGINATION_VALUE);
+    }
+
+    public static function generateUniqueIdentifier()
+    {
+        $dateToday = Carbon::parse(now())->format('mdY');
+        $randomNum = rand(0001, 9999);
+        return "$dateToday-$randomNum";
     }
 
     public static function getInitialStatus($serviceType)
@@ -153,6 +161,7 @@ public function prettyServiceType()
         $this->status=$this->getNextFlow("prev");
         $this->save();
     }
+
 
 
     public function customer()

--- a/database/migrations/2021_04_27_081704_create_services_table.php
+++ b/database/migrations/2021_04_27_081704_create_services_table.php
@@ -23,6 +23,7 @@ class CreateServicesTable extends Migration
             $table->date('date_completed')->nullable();
             $table->string('status');
             $table->string('start_status');
+            $table->string('request_number');
             $table->timestamps();
             $table->foreign('customer_id')->references('account_number')->on('customers')->onDelete('cascade');
         });

--- a/database/seeders/ServicesListSeeder.php
+++ b/database/seeders/ServicesListSeeder.php
@@ -21,7 +21,8 @@ class ServicesListSeeder extends Seeder
             'customer_id' => $customer->account_number,
             'type_of_service' => 'new_connection',
             'status' => 'pending_building_inspection',
-            'start_status' => 'pending_building_inspection'
+            'start_status' => 'pending_building_inspection',
+            'request_number' => Service::generateUniqueIdentifier()
         ]);
     }
 }

--- a/resources/views/pages/services-list.blade.php
+++ b/resources/views/pages/services-list.blade.php
@@ -30,6 +30,7 @@
                 <table class="table mb-0">
                     <thead>
                         <tr>
+                            <td scope="col" class="border-bottom-0 py-3"><strong>REQUEST NUMBER</strong></td>
                             <td scope="col" class="border-bottom-0 py-3"><strong>FULL NAME</strong></td>
                             <td scope="col" class="border-bottom-0 py-3"><strong>TYPE OF SERVICE</strong></td>
                             <td scope="col" class="border-bottom-0 py-3"><strong>REMARKS</strong></td>
@@ -42,6 +43,7 @@
                     <tbody>
                         @forelse ($services as $service)
                             <tr>
+                                <td scope="row" class="border-bottom-0 border-top">{{$service->request_number}}</td>
                                 <td scope="row" class="border-bottom-0 border-top">{{$service->customer->fullname()}}</td>
                                 <td scope="row" class="border-bottom-0 border-top">{{ $service->prettyType()}}</td>
                                 <td scope="row" class="border-bottom-0 border-top">{{$service->remarks}}</td>
@@ -62,7 +64,7 @@
                             </tr>
                         @empty
                             <tr>
-                                <td colspan="6" class="text-center border-top border-bottom-0">No records yet!</td>
+                                <td colspan="10" class="text-center border-top border-bottom-0">No records yet!</td>
                             </tr>
                         @endforelse
                     </tbody>

--- a/routes/web.php
+++ b/routes/web.php
@@ -74,8 +74,8 @@ Route::prefix('admin')->middleware(['auth'])->name('admin.')->group(function(){
 
 
 
-    Route::get('/service-list', [ServiceListController::class, 'index'])->name('services-list.index');
-    Route::get('/service-list/filter', [ServiceListController::class, 'filter'])->name('services-list.filter');
+    // Route::get('/service-list', [ServiceListController::class, 'index'])->name('services-list.index');
+    // Route::get('/service-list/filter', [ServiceListController::class, 'filter'])->name('services-list.filter');
 
     // Export URLs
     Route::get('/customers/export/{keyword?}',[ExportsController::class,'exportCustomers'])->name('customers.export');

--- a/tests/Feature/ServicesListTest.php
+++ b/tests/Feature/ServicesListTest.php
@@ -19,7 +19,8 @@ class ServicesListTest extends TestCase
             'customer_id' => $customer->account_number,
             'type_of_service' => 'new_connection',
             'status' => Service::$PENDING_BUILDING_INSPECTION,
-            'start_status' => Service::$PENDING_BUILDING_INSPECTION
+            'start_status' => Service::$PENDING_BUILDING_INSPECTION,
+            'request_number' => Service::generateUniqueIdentifier()
         ]);
         $response = $this->actingAs($user)->get(route('admin.services-list.index'));
         $response->assertViewIs('pages.services-list');

--- a/tests/Feature/ServicesListTest.php
+++ b/tests/Feature/ServicesListTest.php
@@ -22,7 +22,7 @@ class ServicesListTest extends TestCase
             'start_status' => Service::$PENDING_BUILDING_INSPECTION,
             'request_number' => Service::generateUniqueIdentifier()
         ]);
-        $response = $this->actingAs($user)->get(route('admin.services-list.index'));
+        $response = $this->actingAs($user)->get(route('admin.services.index'));
         $response->assertViewIs('pages.services-list');
         $response->assertViewHas('services');
     }


### PR DESCRIPTION
Since in the WOR, ID is not good to be displayed especially if that ID will be above 1K it going to destroy 
or misalign the design. So the solution for this is we use the **Request Number**

In migration, I simply added another column and name it `request_number`. This `request_number` value format will be mmddyyyy-(some random number). Example 01092000-1234
 This random number will range from 0001 to 9999. So I create a static function to handle that. 

For migration:
![image](https://user-images.githubusercontent.com/43285621/135096913-2ad830f1-1845-4bff-9e35-9650ec77f2e5.png)

In Service Model:
![image](https://user-images.githubusercontent.com/43285621/135097004-3c91ce38-a11f-4021-8608-9f0c20977956.png)

The function that will generate the value for request_number:
![image](https://user-images.githubusercontent.com/43285621/135097494-fcaf4d66-0307-4282-b1fc-4a75f10f3c1e.png)


The thing that I found that can cause a problem for this function is, In 1 in a million there will be a chance that the generated number will be the same as the existing request_number value. Which can cause conflict to other Services. Especially if the admin is going to search it by its `request_number`.

For my suggestion, after generating a random number it will look up to the database if this random number exists if does it will regenerate again, then if theirs no existing random number that matches the generated number then it will save. Just kindly tell me if you agree to my suggestion. 